### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,4 +1,5 @@
 name: Deploy Frontend to Render
+permissions: {}
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ALTHAFHUSSAINSYED/portfolio/security/code-scanning/1](https://github.com/ALTHAFHUSSAINSYED/portfolio/security/code-scanning/1)

The best way to fix the problem is to add a `permissions` block specifying only the minimal required permissions for this job or workflow. Since this workflow simply triggers a deployment by making a POST request using `curl` to an external service and doesn't perform any GitHub API calls or require write access to the repo, the minimal setting is `permissions: {}` (which denies all permissions), or alternatively  
`permissions: read-all` (to allow read-only), or more restrictively specify nothing as needed.

- The standard practice is to add the block at the workflow's root, directly after the `name:` line and before `on:` so it applies to all jobs.
- No method, import, or definition changes are required beyond adding the `permissions` line(s).
- No existing functionality will change since no GitHub-related steps are in use.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
